### PR TITLE
chore: using PSR version < 10.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "python-semantic-release",
+    "python-semantic-release<10.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
The release of the version [10.0.0](https://python-semantic-release.readthedocs.io/en/stable/upgrading/10-upgrade.html) of python-semantic-release (PSR) introduced a set of breaking changes. To remediate this situation, we constrain the PSR version to <10.0.0, allowing us to get the release working with the same configuration.