### PR TITLE
feat: added used and availability of memory disk and services status

### DIFF
--- a/dashboards/instances-performance.json
+++ b/dashboards/instances-performance.json
@@ -968,12 +968,218 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Use and availability of exact usage by mount point in percentage.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Use%"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "orange",
+                      "value": 80
+                    },
+                    {
+                      "color": "red",
+                      "value": 90
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avail%"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": 0
+                    },
+                    {
+                      "color": "orange",
+                      "value": 15
+                    },
+                    {
+                      "color": "green",
+                      "value": 30
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 901,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"} - node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "Used"
+        },
+        {
+          "editorMode": "code",
+          "expr": "node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "Size"
+        },
+        {
+          "editorMode": "code",
+          "expr": "(node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}) * 100",
+          "format": "table",
+          "instant": true,
+          "refId": "Avail%"
+        },
+        {
+          "editorMode": "code",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}) * 100",
+          "format": "table",
+          "instant": true,
+          "refId": "Use%"
+        }
+      ],
+      "title": "Filesystems (exact)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "device": true,
+              "fstype": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {
+              "Value #Avail%": 3,
+              "Value #Size": 2,
+              "Value #Use%": 4,
+              "Value #Used": 1,
+              "mountpoint": 0
+            },
+            "renameByName": {
+              "Value #Avail%": "Avail%",
+              "Value #Size": "Total",
+              "Value #Use%": "Use%",
+              "Value #Used": "Used",
+              "mountpoint": "Mount"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 11
       },
       "id": 263,
       "panels": [
@@ -1626,7 +1832,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 12
       },
       "id": 265,
       "panels": [
@@ -3155,7 +3361,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 270,
       "panels": [
@@ -3174,7 +3380,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "read (\u2013) / write (+)",
+                "axisLabel": "read (–) / write (+)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -3306,7 +3512,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "read (\u2013) / write (+)",
+                "axisLabel": "read (–) / write (+)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -3442,7 +3648,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "read (\u2013) / write (+)",
+                "axisLabel": "read (–) / write (+)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -3690,7 +3896,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "read (\u2013) / write (+)",
+                "axisLabel": "read (–) / write (+)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -3743,7 +3949,9 @@
                     "value": "negative-Y"
                   }
                 ]
-              },
+              }
+            ],
+            "overrides": [
               {
                 "matcher": {
                   "id": "byRegexp",
@@ -4307,12 +4515,94 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 14
       },
       "id": 279,
       "panels": [],
-      "title": "Node Exporter",
+      "title": "Node Exporter and Services Status",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "UP/DOWN of Mongo, MySQL/MariaDB, Redis and ClickHouse in the node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 911,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "node_systemd_unit_state{instance=~\"$node\",job=~\"$job\",state=\"active\",name=~\"mongod.*|mysqld?.*|mariadb.*|redis.*|clickhouse.*\"}",
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Service Status (systemd)",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -4382,7 +4672,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 18
       },
       "id": 40,
       "options": {
@@ -4482,7 +4772,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 18
       },
       "id": 308,
       "options": {
@@ -4637,7 +4927,7 @@
         "h": 10,
         "w": 10,
         "x": 0,
-        "y": 100
+        "y": 28
       },
       "id": 149,
       "options": {
@@ -4800,7 +5090,7 @@
         "h": 10,
         "w": 10,
         "x": 10,
-        "y": 100
+        "y": 28
       },
       "id": 64,
       "options": {
@@ -4882,7 +5172,7 @@
         "h": 10,
         "w": 4,
         "x": 20,
-        "y": 100
+        "y": 28
       },
       "id": 157,
       "options": {
@@ -5037,5 +5327,5 @@
   "timezone": "browser",
   "title": "Infrastructure / Instances Performance",
   "uid": "Instances-performance",
-  "version": 1
+  "version": 8
 }

--- a/dashboards/instances-performance.json
+++ b/dashboards/instances-performance.json
@@ -972,7 +972,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Use and availability of exact usage by mount point in percentage.",
+      "description": "Exact usage by mount point.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1043,49 +1043,6 @@
                 }
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Avail%"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "max",
-                "value": 100
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 15
-                    },
-                    {
-                      "color": "green",
-                      "value": 30
-                    }
-                  ]
-                }
-              }
-            ]
           }
         ]
       },
@@ -1111,34 +1068,27 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"} - node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype=~\"ext4|xfs\"} - node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype=~\"ext4|xfs\"}",
           "format": "table",
           "instant": true,
           "refId": "Used"
         },
         {
           "editorMode": "code",
-          "expr": "node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}",
+          "expr": "node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype=~\"ext4|xfs\"}",
           "format": "table",
           "instant": true,
           "refId": "Size"
         },
         {
           "editorMode": "code",
-          "expr": "(node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}) * 100",
-          "format": "table",
-          "instant": true,
-          "refId": "Avail%"
-        },
-        {
-          "editorMode": "code",
-          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype!~\"tmpfs|overlay|squashfs\"}) * 100",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$node\",job=~\"$job\",fstype=~\"ext4|xfs\"} / node_filesystem_size_bytes{instance=~\"$node\",job=~\"$job\",fstype=~\"ext4|xfs\"}) * 100",
           "format": "table",
           "instant": true,
           "refId": "Use%"
         }
       ],
-      "title": "Filesystems (exact)",
+      "title": "Disk Usage",
       "transformations": [
         {
           "id": "merge",
@@ -1149,20 +1099,21 @@
           "options": {
             "excludeByName": {
               "Time": true,
+              "__name__": true,
+              "cluster": true,
               "device": true,
               "fstype": true,
               "instance": true,
-              "job": true
+              "job": true,
+              "role": true
             },
             "indexByName": {
-              "Value #Avail%": 3,
               "Value #Size": 2,
-              "Value #Use%": 4,
+              "Value #Use%": 3,
               "Value #Used": 1,
               "mountpoint": 0
             },
             "renameByName": {
-              "Value #Avail%": "Avail%",
               "Value #Size": "Total",
               "Value #Use%": "Use%",
               "Value #Used": "Used",
@@ -4519,90 +4470,8 @@
       },
       "id": 279,
       "panels": [],
-      "title": "Node Exporter and Services Status",
+      "title": "Node Exporter",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "UP/DOWN of Mongo, MySQL/MariaDB, Redis and ClickHouse in the node.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "DOWN"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "UP"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 911,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "node_systemd_unit_state{instance=~\"$node\",job=~\"$job\",state=\"active\",name=~\"mongod.*|mysqld?.*|mariadb.*|redis.*|clickhouse.*\"}",
-          "instant": true,
-          "legendFormat": "{{name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Service Status (systemd)",
-      "type": "stat"
     },
     {
       "datasource": {


### PR DESCRIPTION
# Description

- Added "Disk Usage" Panel:

  - Introduced a new table panel displaying exact disk capacity metrics: Mount, Used, Total, and Use%.

  - Implemented explicit PromQL regex filtering (fstype=~"ext4|xfs") to target only relevant persistent storage, dropping the previous exclusion logic to improve query precision.

  - Added visual gradient thresholds on the Use% column for quick capacity assessment (e.g., transitioning to orange/red as the disk fills up).

<img width="1663" height="545" alt="image" src="https://github.com/user-attachments/assets/3a0e3dfa-4894-496c-ad72-c92e052ab190" />



